### PR TITLE
Move buckets in demo/image-path-search to dataset configs

### DIFF
--- a/demos/image-patch-search/config.py
+++ b/demos/image-patch-search/config.py
@@ -1,10 +1,9 @@
-from lvis_config import IMAGE_LIST_PATH, DEMO_IMAGES
+from lvis_config import IMAGE_BUCKET, IMAGE_LIST_PATH, DEMO_IMAGES
 
 N_RESULTS_TO_DISPLAY = 50
 N_CONCURRENT_WORKERS_DEFAULT = 350
 
 HANDLER_URL = "https://knn-wj4n6yaj3q-uw.a.run.app"
-IMAGE_BUCKET = "mihir-knn"
 IMAGE_URL_PREFIX = f"https://storage.googleapis.com/{IMAGE_BUCKET}/"
 
 QUERY_CLEANUP_TIME = 60 * 60  # seconds

--- a/demos/image-patch-search/df2_config.py
+++ b/demos/image-patch-search/df2_config.py
@@ -1,3 +1,4 @@
+IMAGE_BUCKET = "mihir-knn"
 IMAGE_LIST_PATH = "df2_images.txt"
 
 DEMO_IMAGES = [

--- a/demos/image-patch-search/lvis_config.py
+++ b/demos/image-patch-search/lvis_config.py
@@ -1,3 +1,4 @@
+IMAGE_BUCKET = "mihir-knn"
 IMAGE_LIST_PATH = "lvis_images.txt"
 
 DEMO_IMAGES = [


### PR DESCRIPTION
Moving the GCS bucket into the individual dataset configs in the image path search demo.